### PR TITLE
[object] Fix hit_test for outlined objects

### DIFF
--- a/src/game/fidget.rs
+++ b/src/game/fidget.rs
@@ -49,7 +49,7 @@ impl Fidget {
                     if obj.flags.contains(Flag::TurnedOff) ||
                         obj.fid.kind() != EntityKind::Critter ||
                         obj.is_critter_dead() ||
-                        !world.object_bounds(objh).intersects(world.camera().viewport)
+                        !world.object_bounds(objh, true).intersects(world.camera().viewport)
                     // FIXME
                     // g_map_header.map_id == MAP_ID_WOODSMAN_ENCOUNTER && obj.pid == Some(Pid::ENCLAVE_PATROL)
                     {

--- a/src/game/world.rs
+++ b/src/game/world.rs
@@ -232,12 +232,12 @@ impl World {
         }
     }
 
-    pub fn object_bounds(&self, obj: object::Handle) -> Rect {
-        self.objects.bounds(obj, &self.camera.hex())
+    pub fn object_bounds(&self, obj: object::Handle, include_outline: bool) -> Rect {
+        self.objects.bounds(obj, &self.camera.hex(), include_outline)
     }
 
     pub fn is_object_in_camera(&self, obj: object::Handle) -> bool {
-        let bounds = self.object_bounds(obj);
+        let bounds = self.object_bounds(obj, true);
         self.camera.viewport.intersects(bounds)
     }
 

--- a/src/graphics/sprite.rs
+++ b/src/graphics/sprite.rs
@@ -120,12 +120,15 @@ impl Mask {
     }
 
     #[must_use]
-    pub fn test(&self, point: Point) -> bool {
+    pub fn test(&self, point: Point) -> Option<bool> {
+        if point.x >= self.width {
+            return None;
+        }
         let Point { x, y } = point;
         let i = x + y * self.width;
+        let b = self.bitmask.get(i as usize / 8)?;
         let bit = i % 8;
-        let i = i as usize / 8;
-        self.bitmask[i] & (1 << bit) != 0
+        Some(b & (1 << bit) != 0)
     }
 }
 
@@ -272,10 +275,13 @@ mod test {
         fn test() {
             let mask = Mask::new(3, &[0, 1, 0, 2, 0, 100]);
             assert_eq!(&*mask.bitmask, &[0b101010]);
-            assert_eq!(mask.test((0, 0).into()), false);
-            assert_eq!(mask.test((1, 0).into()), true);
-            assert_eq!(mask.test((0, 1).into()), true);
-            assert_eq!(mask.test((1, 1).into()), false);
+            assert_eq!(mask.test((0, 0).into()), Some(false));
+            assert_eq!(mask.test((1, 0).into()), Some(true));
+            assert_eq!(mask.test((0, 1).into()), Some(true));
+            assert_eq!(mask.test((1, 1).into()), Some(false));
+            assert_eq!(mask.test((2, 1).into()), Some(true));
+            assert_eq!(mask.test((3, 1).into()), None);
+            assert_eq!(mask.test((2, 2).into()), None);
         }
     }
 }


### PR DESCRIPTION
For now hitting outline doesn't pass the hit_test.
(Seems to be the original behavior too.)